### PR TITLE
LDOP-158 Minor changes to Jenkinsfile to add a tag to be used for CI …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,8 @@ pipeline {
         stage('ldop-gerrit-validate') {
             agent any
             steps {
-                sh "echo \$(git tag --sort version:refname | tail -1) > result"
+                sh "git pull origin ${env.BRANCH_NAME}"
+                sh "echo \$(git tag -l | sort -V | tail -1) > result"
                 script {
                     TAG = readFile 'result'
                     TAG = TAG.trim()


### PR DESCRIPTION
…testing.

These changes are necessary for the Jenkinsfile to work on build.liatrio.com. They ensure that the most recent tags are present when the CI runs, and that the git command to get the correct version works with git <2.x.